### PR TITLE
Changes to Encounter/Dialogue load so they don't have to be declared in mystery-encounters.ts

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -98,7 +98,7 @@ import {
   allMysteryEncounters,
   BASE_MYSTERY_ENCOUNTER_SPAWN_WEIGHT,
   AVERAGE_ENCOUNTERS_PER_RUN_TARGET, WIGHT_INCREMENT_ON_SPAWN_MISS
-} from "./data/mystery-encounters/encounters/mystery-encounters";
+} from "./data/mystery-encounters/mystery-encounters";
 import { MysteryEncounterData } from "#app/data/mystery-encounters/mystery-encounter-data";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 

--- a/src/data/mystery-encounters/mystery-encounter-data.ts
+++ b/src/data/mystery-encounters/mystery-encounter-data.ts
@@ -1,6 +1,6 @@
 import { MysteryEncounterTier } from "#app/data/mystery-encounters/mystery-encounter";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
-import { BASE_MYSTERY_ENCOUNTER_SPAWN_WEIGHT } from "#app/data/mystery-encounters/encounters/mystery-encounters";
+import { BASE_MYSTERY_ENCOUNTER_SPAWN_WEIGHT } from "#app/data/mystery-encounters/mystery-encounters";
 import { isNullOrUndefined } from "#app/utils";
 
 export class MysteryEncounterData {

--- a/src/data/mystery-encounters/mystery-encounter-dialogue.ts
+++ b/src/data/mystery-encounters/mystery-encounter-dialogue.ts
@@ -37,11 +37,6 @@ export default class MysteryEncounterDialogue {
   outro?: TextDisplay[];
 }
 
-export interface EncounterTypeDialogue {
-  [key: integer]: MysteryEncounterDialogue
-}
-
-
 /**
  * Example MysteryEncounterDialogue object:
  *
@@ -86,8 +81,7 @@ export interface EncounterTypeDialogue {
  *
  */
 
-
-export const allMysteryEncounterDialogue: EncounterTypeDialogue = {};
+export const allMysteryEncounterDialogue: { [encounterType: number]: MysteryEncounterDialogue } = {};
 
 export function initMysteryEncounterDialogue() {
   allMysteryEncounterDialogue[MysteryEncounterType.MYSTERIOUS_CHALLENGERS] = MysteriousChallengersDialogue;

--- a/src/data/mystery-encounters/mystery-encounter-utils.ts
+++ b/src/data/mystery-encounters/mystery-encounter-utils.ts
@@ -46,7 +46,7 @@ import { biomeLinks } from "#app/data/biomes";
 import { Mode } from "#app/ui/ui";
 import { PartyOption, PartyUiMode } from "#app/ui/party-ui-handler";
 import { OptionSelectConfig, OptionSelectItem } from "#app/ui/abstact-option-select-ui-handler";
-import { WIGHT_INCREMENT_ON_SPAWN_MISS } from "#app/data/mystery-encounters/encounters/mystery-encounters";
+import { WIGHT_INCREMENT_ON_SPAWN_MISS } from "#app/data/mystery-encounters/mystery-encounters";
 import { getTextWithColors, TextStyle } from "#app/ui/text";
 import * as Overrides from "#app/overrides";
 import { UiTheme } from "#enums/ui-theme";

--- a/src/data/mystery-encounters/mystery-encounters.ts
+++ b/src/data/mystery-encounters/mystery-encounters.ts
@@ -1,11 +1,11 @@
-import MysteryEncounter from "../mystery-encounter";
-import { DarkDealEncounter } from "./dark-deal";
-import { MysteriousChallengersEncounter } from "./mysterious-challengers";
-import { MysteriousChestEncounter } from "./mysterious-chest";
+import MysteryEncounter from "./mystery-encounter";
+import { DarkDealEncounter } from "./encounters/dark-deal";
+import { MysteriousChallengersEncounter } from "./encounters/mysterious-challengers";
+import { MysteriousChestEncounter } from "./encounters/mysterious-chest";
 import { FightOrFlightEncounter } from "#app/data/mystery-encounters/encounters/fight-or-flight";
 import { TrainingSessionEncounter } from "#app/data/mystery-encounters/encounters/training-session";
 import { Biome } from "#enums/biome";
-import { SleepingSnorlaxEncounter } from "./sleeping-snorlax";
+import { SleepingSnorlaxEncounter } from "./encounters/sleeping-snorlax";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { DepartmentStoreSaleEncounter } from "#app/data/mystery-encounters/encounters/department-store-sale";
 import { ShadyVitaminDealerEncounter } from "#app/data/mystery-encounters/encounters/shady-vitamin-dealer";
@@ -15,7 +15,7 @@ export const BASE_MYSTERY_ENCOUNTER_SPAWN_WEIGHT = 1;
 export const WIGHT_INCREMENT_ON_SPAWN_MISS = 5;
 export const AVERAGE_ENCOUNTERS_PER_RUN_TARGET = 15;
 
-export const allMysteryEncounters: { [encounterType: string]: MysteryEncounter } = {};
+export const allMysteryEncounters: { [encounterType: number]: MysteryEncounter } = {};
 
 // Add MysteryEncounterType to biomes to enable it exclusively for those biomes
 // To enable an encounter in all biomes, do not add to this map
@@ -86,8 +86,6 @@ export const mysteryEncountersByBiome = new Map<Biome, MysteryEncounterType[]>([
   [Biome.LABORATORY, []]
 ]);
 
-// Only add your MysterEncounter here if you want it to be in every biome.
-// We recommend designing biome-specific encounters for better flavor and variance
 export function initMysteryEncounters() {
   allMysteryEncounters[MysteryEncounterType.MYSTERIOUS_CHALLENGERS] = MysteriousChallengersEncounter;
   allMysteryEncounters[MysteryEncounterType.MYSTERIOUS_CHEST] = MysteriousChestEncounter;

--- a/src/loading-scene.ts
+++ b/src/loading-scene.ts
@@ -23,7 +23,7 @@ import { initVouchers } from "./system/voucher";
 import { Biome } from "#enums/biome";
 import { TrainerType } from "#enums/trainer-type";
 import {initMysteryEncounterDialogue} from "#app/data/mystery-encounters/mystery-encounter-dialogue";
-import {initMysteryEncounters} from "#app/data/mystery-encounters/encounters/mystery-encounters";
+import {initMysteryEncounters} from "#app/data/mystery-encounters/mystery-encounters";
 
 export class LoadingScene extends SceneBase {
   readonly LOAD_EVENTS = Phaser.Loader.Events;

--- a/src/test/vitest.setup.ts
+++ b/src/test/vitest.setup.ts
@@ -15,7 +15,7 @@ import { initStatsKeys } from "#app/ui/game-stats-ui-handler";
 import { beforeAll, beforeEach, vi } from "vitest";
 import * as overrides from "#app/overrides";
 import {initMysteryEncounterDialogue} from "#app/data/mystery-encounters/mystery-encounter-dialogue";
-import {initMysteryEncounters} from "#app/data/mystery-encounters/encounters/mystery-encounters";
+import {initMysteryEncounters} from "#app/data/mystery-encounters/mystery-encounters";
 
 initVouchers();
 initAchievements();


### PR DESCRIPTION
as far as I can tell, there's no way to altogether remove manual declarations of the encounter/dialogue objects that are created. Cleaned up the code a little bit though