### PR TITLE
add option mode for UI styling consistency

### DIFF
--- a/src/data/mystery-encounters/encounters/department-store-sale-encounter.ts
+++ b/src/data/mystery-encounters/encounters/department-store-sale-encounter.ts
@@ -16,9 +16,7 @@ import IMysteryEncounter, {
 const namespace = "mysteryEncounter:department_store_sale";
 
 export const DepartmentStoreSaleEncounter: IMysteryEncounter =
-  MysteryEncounterBuilder.withEncounterType(
-    MysteryEncounterType.DEPARTMENT_STORE_SALE
-  )
+  MysteryEncounterBuilder.withEncounterType(MysteryEncounterType.DEPARTMENT_STORE_SALE)
     .withEncounterTier(MysteryEncounterTier.COMMON)
     .withSceneWaveRangeRequirement(10, 100)
     .withIntroSpriteConfigs([
@@ -45,7 +43,7 @@ export const DepartmentStoreSaleEncounter: IMysteryEncounter =
         speaker: `${namespace}_speaker`,
       },
     ])
-    // .withHideIntroVisuals(false)
+    .withHideIntroVisuals(false)
     .withTitle(`${namespace}_title`)
     .withDescription(`${namespace}_description`)
     .withQuery(`${namespace}_query`)
@@ -71,10 +69,7 @@ export const DepartmentStoreSaleEncounter: IMysteryEncounter =
           i++;
         }
 
-        setEncounterRewards(scene, {
-          guaranteedModifierTypeFuncs: modifiers,
-          fillRemaining: false,
-        });
+        setEncounterRewards(scene, { guaranteedModifierTypeFuncs: modifiers, fillRemaining: false, });
         leaveEncounterWithoutBattle(scene);
       }
     )
@@ -98,10 +93,7 @@ export const DepartmentStoreSaleEncounter: IMysteryEncounter =
           i++;
         }
 
-        setEncounterRewards(scene, {
-          guaranteedModifierTypeFuncs: modifiers,
-          fillRemaining: false,
-        });
+        setEncounterRewards(scene, { guaranteedModifierTypeFuncs: modifiers, fillRemaining: false, });
         leaveEncounterWithoutBattle(scene);
       }
     )
@@ -125,10 +117,7 @@ export const DepartmentStoreSaleEncounter: IMysteryEncounter =
           i++;
         }
 
-        setEncounterRewards(scene, {
-          guaranteedModifierTypeFuncs: modifiers,
-          fillRemaining: false,
-        });
+        setEncounterRewards(scene, { guaranteedModifierTypeFuncs: modifiers, fillRemaining: false, });
         leaveEncounterWithoutBattle(scene);
       }
     )
@@ -156,10 +145,7 @@ export const DepartmentStoreSaleEncounter: IMysteryEncounter =
           i++;
         }
 
-        setEncounterRewards(scene, {
-          guaranteedModifierTypeFuncs: modifiers,
-          fillRemaining: false,
-        });
+        setEncounterRewards(scene, { guaranteedModifierTypeFuncs: modifiers, fillRemaining: false, });
         leaveEncounterWithoutBattle(scene);
       }
     )

--- a/src/data/mystery-encounters/encounters/field-trip-encounter.ts
+++ b/src/data/mystery-encounters/encounters/field-trip-encounter.ts
@@ -1,5 +1,5 @@
 import { MoveCategory } from "#app/data/move";
-import { MysteryEncounterOptionBuilder } from "#app/data/mystery-encounters/mystery-encounter-option";
+import { EncounterOptionMode, MysteryEncounterOptionBuilder } from "#app/data/mystery-encounters/mystery-encounter-option";
 import {
   generateModifierTypeOption,
   leaveEncounterWithoutBattle,
@@ -57,6 +57,7 @@ export const FieldTripEncounter: IMysteryEncounter =
     .withQuery(`${namespace}_query`)
     .withOption(
       new MysteryEncounterOptionBuilder()
+        .withOptionMode(EncounterOptionMode.DEFAULT)
         .withDialogue({
           buttonLabel: `${namespace}_option_1_label`,
           buttonTooltip: `${namespace}_option_1_tooltip`,
@@ -76,8 +77,7 @@ export const FieldTripEncounter: IMysteryEncounter =
                 label: move.getName(),
                 handler: () => {
                   // Pokemon and move selected
-                  const correctMove =
-                    move.getMove().category === MoveCategory.PHYSICAL;
+                  const correctMove = move.getMove().category === MoveCategory.PHYSICAL;
                   encounter.setDialogueToken("moveCategory", "Physical");
                   if (!correctMove) {
                     encounter.options[0].dialogue.selected = [
@@ -89,11 +89,7 @@ export const FieldTripEncounter: IMysteryEncounter =
                         text: `${namespace}_lesson_learned`,
                       },
                     ];
-                    setEncounterExp(
-                      scene,
-                      scene.getParty().map((p) => p.id),
-                      50
-                    );
+                    setEncounterExp(scene, scene.getParty().map((p) => p.id), 50);
                   } else {
                     encounter.setDialogueToken("pokeName", pokemon.name);
                     encounter.setDialogueToken("move", move.getName());
@@ -120,28 +116,13 @@ export const FieldTripEncounter: IMysteryEncounter =
           const encounter = scene.currentBattle.mysteryEncounter;
           if (encounter.misc.correctMove) {
             const modifiers = [
-              generateModifierTypeOption(
-                scene,
-                modifierTypes.TEMP_STAT_BOOSTER,
-                [TempBattleStat.ATK]
-              ),
-              generateModifierTypeOption(
-                scene,
-                modifierTypes.TEMP_STAT_BOOSTER,
-                [TempBattleStat.DEF]
-              ),
-              generateModifierTypeOption(
-                scene,
-                modifierTypes.TEMP_STAT_BOOSTER,
-                [TempBattleStat.SPD]
-              ),
+              generateModifierTypeOption(scene, modifierTypes.TEMP_STAT_BOOSTER, [TempBattleStat.ATK]),
+              generateModifierTypeOption(scene, modifierTypes.TEMP_STAT_BOOSTER, [TempBattleStat.DEF]),
+              generateModifierTypeOption(scene, modifierTypes.TEMP_STAT_BOOSTER, [TempBattleStat.SPD]),
               generateModifierTypeOption(scene, modifierTypes.DIRE_HIT),
             ];
 
-            setEncounterRewards(scene, {
-              guaranteedModifierTypeOptions: modifiers,
-              fillRemaining: false,
-            });
+            setEncounterRewards(scene, { guaranteedModifierTypeOptions: modifiers, fillRemaining: false });
           }
 
           leaveEncounterWithoutBattle(scene, !encounter.misc.correctMove);
@@ -150,6 +131,7 @@ export const FieldTripEncounter: IMysteryEncounter =
     )
     .withOption(
       new MysteryEncounterOptionBuilder()
+        .withOptionMode(EncounterOptionMode.DEFAULT)
         .withDialogue({
           buttonLabel: `${namespace}_option_2_label`,
           buttonTooltip: `${namespace}_option_2_tooltip`,
@@ -169,8 +151,7 @@ export const FieldTripEncounter: IMysteryEncounter =
                 label: move.getName(),
                 handler: () => {
                   // Pokemon and move selected
-                  const correctMove =
-                    move.getMove().category === MoveCategory.SPECIAL;
+                  const correctMove = move.getMove().category === MoveCategory.SPECIAL;
                   encounter.setDialogueToken("moveCategory", "Special");
                   if (!correctMove) {
                     encounter.options[1].dialogue.selected = [
@@ -182,11 +163,7 @@ export const FieldTripEncounter: IMysteryEncounter =
                         text: `${namespace}_lesson_learned`,
                       },
                     ];
-                    setEncounterExp(
-                      scene,
-                      scene.getParty().map((p) => p.id),
-                      50
-                    );
+                    setEncounterExp(scene, scene.getParty().map((p) => p.id), 50);
                   } else {
                     encounter.setDialogueToken("pokeName", pokemon.name);
                     encounter.setDialogueToken("move", move.getName());
@@ -213,28 +190,13 @@ export const FieldTripEncounter: IMysteryEncounter =
           const encounter = scene.currentBattle.mysteryEncounter;
           if (encounter.misc.correctMove) {
             const modifiers = [
-              generateModifierTypeOption(
-                scene,
-                modifierTypes.TEMP_STAT_BOOSTER,
-                [TempBattleStat.SPATK]
-              ),
-              generateModifierTypeOption(
-                scene,
-                modifierTypes.TEMP_STAT_BOOSTER,
-                [TempBattleStat.SPDEF]
-              ),
-              generateModifierTypeOption(
-                scene,
-                modifierTypes.TEMP_STAT_BOOSTER,
-                [TempBattleStat.SPD]
-              ),
+              generateModifierTypeOption(scene, modifierTypes.TEMP_STAT_BOOSTER, [TempBattleStat.SPATK]),
+              generateModifierTypeOption(scene, modifierTypes.TEMP_STAT_BOOSTER, [TempBattleStat.SPDEF]),
+              generateModifierTypeOption(scene, modifierTypes.TEMP_STAT_BOOSTER, [TempBattleStat.SPD]),
               generateModifierTypeOption(scene, modifierTypes.DIRE_HIT),
             ];
 
-            setEncounterRewards(scene, {
-              guaranteedModifierTypeOptions: modifiers,
-              fillRemaining: false,
-            });
+            setEncounterRewards(scene, { guaranteedModifierTypeOptions: modifiers, fillRemaining: false });
           }
 
           leaveEncounterWithoutBattle(scene, !encounter.misc.correctMove);
@@ -243,6 +205,7 @@ export const FieldTripEncounter: IMysteryEncounter =
     )
     .withOption(
       new MysteryEncounterOptionBuilder()
+        .withOptionMode(EncounterOptionMode.DEFAULT)
         .withDialogue({
           buttonLabel: `${namespace}_option_3_label`,
           buttonTooltip: `${namespace}_option_3_tooltip`,
@@ -262,8 +225,7 @@ export const FieldTripEncounter: IMysteryEncounter =
                 label: move.getName(),
                 handler: () => {
                   // Pokemon and move selected
-                  const correctMove =
-                    move.getMove().category === MoveCategory.STATUS;
+                  const correctMove = move.getMove().category === MoveCategory.STATUS;
                   encounter.setDialogueToken("moveCategory", "Status");
                   if (!correctMove) {
                     encounter.options[2].dialogue.selected = [
@@ -306,24 +268,13 @@ export const FieldTripEncounter: IMysteryEncounter =
           const encounter = scene.currentBattle.mysteryEncounter;
           if (encounter.misc.correctMove) {
             const modifiers = [
-              generateModifierTypeOption(
-                scene,
-                modifierTypes.TEMP_STAT_BOOSTER,
-                [TempBattleStat.ACC]
-              ),
-              generateModifierTypeOption(
-                scene,
-                modifierTypes.TEMP_STAT_BOOSTER,
-                [TempBattleStat.SPD]
-              ),
+              generateModifierTypeOption(scene, modifierTypes.TEMP_STAT_BOOSTER, [TempBattleStat.ACC]),
+              generateModifierTypeOption(scene, modifierTypes.TEMP_STAT_BOOSTER, [TempBattleStat.SPD]),
               generateModifierTypeOption(scene, modifierTypes.GREAT_BALL),
               generateModifierTypeOption(scene, modifierTypes.IV_SCANNER),
             ];
 
-            setEncounterRewards(scene, {
-              guaranteedModifierTypeOptions: modifiers,
-              fillRemaining: false,
-            });
+            setEncounterRewards(scene, { guaranteedModifierTypeOptions: modifiers, fillRemaining: false });
           }
 
           leaveEncounterWithoutBattle(scene, !encounter.misc.correctMove);

--- a/src/data/mystery-encounters/encounters/fight-or-flight-encounter.ts
+++ b/src/data/mystery-encounters/encounters/fight-or-flight-encounter.ts
@@ -8,7 +8,7 @@ import {
   setEncounterRewards,
   showEncounterText,
 } from "#app/data/mystery-encounters/mystery-encounter-utils";
-import {  STEALING_MOVES } from "#app/data/mystery-encounters/requirements/requirement-groups";
+import { STEALING_MOVES } from "#app/data/mystery-encounters/requirements/requirement-groups";
 import Pokemon from "#app/field/pokemon";
 import { ModifierTier } from "#app/modifier/modifier-tier";
 import {

--- a/src/data/mystery-encounters/encounters/mysterious-challengers-encounter.ts
+++ b/src/data/mystery-encounters/encounters/mysterious-challengers-encounter.ts
@@ -40,18 +40,13 @@ export const MysteriousChallengersEncounter: IMysteryEncounter =
       // Calculates what trainers are available for battle in the encounter
 
       // Normal difficulty trainer is randomly pulled from biome
-      const normalTrainerType = scene.arena.randomTrainerType(
-        scene.currentBattle.waveIndex
-      );
+      const normalTrainerType = scene.arena.randomTrainerType(scene.currentBattle.waveIndex);
       const normalConfig = trainerConfigs[normalTrainerType].copy();
       let female = false;
       if (normalConfig.hasGenders) {
         female = !!Utils.randSeedInt(2);
       }
-      const normalSpriteKey = normalConfig.getSpriteKey(
-        female,
-        normalConfig.doubleOnly
-      );
+      const normalSpriteKey = normalConfig.getSpriteKey(female, normalConfig.doubleOnly);
       encounter.enemyPartyConfigs.push({
         trainerConfig: normalConfig,
         female: female,
@@ -59,9 +54,7 @@ export const MysteriousChallengersEncounter: IMysteryEncounter =
 
       // Hard difficulty trainer is another random trainer, but with AVERAGE_BALANCED config
       // Number of mons is based off wave: 1-20 is 2, 20-40 is 3, etc. capping at 6 after wave 100
-      const hardTrainerType = scene.arena.randomTrainerType(
-        scene.currentBattle.waveIndex
-      );
+      const hardTrainerType = scene.arena.randomTrainerType(scene.currentBattle.waveIndex);
       const hardTemplate = new TrainerPartyCompoundTemplate(
         new TrainerPartyTemplate(1, PartyMemberStrength.STRONGER, false, true),
         new TrainerPartyTemplate(
@@ -77,10 +70,7 @@ export const MysteriousChallengersEncounter: IMysteryEncounter =
       if (hardConfig.hasGenders) {
         female = !!Utils.randSeedInt(2);
       }
-      const hardSpriteKey = hardConfig.getSpriteKey(
-        female,
-        hardConfig.doubleOnly
-      );
+      const hardSpriteKey = hardConfig.getSpriteKey(female, hardConfig.doubleOnly);
       encounter.enemyPartyConfigs.push({
         trainerConfig: hardConfig,
         levelAdditiveMultiplier: 0.5,
@@ -101,10 +91,7 @@ export const MysteriousChallengersEncounter: IMysteryEncounter =
       if (brutalConfig.hasGenders) {
         female = !!Utils.randSeedInt(2);
       }
-      const brutalSpriteKey = brutalConfig.getSpriteKey(
-        female,
-        brutalConfig.doubleOnly
-      );
+      const brutalSpriteKey = brutalConfig.getSpriteKey(female, brutalConfig.doubleOnly);
       encounter.enemyPartyConfigs.push({
         trainerConfig: brutalConfig,
         levelAdditiveMultiplier: 1.1,
@@ -152,14 +139,7 @@ export const MysteriousChallengersEncounter: IMysteryEncounter =
         // Spawn standard trainer battle with memory mushroom reward
         const config: EnemyPartyConfig = encounter.enemyPartyConfigs[0];
 
-        setEncounterRewards(scene, {
-          guaranteedModifierTypeFuncs: [
-            modifierTypes.TM_COMMON,
-            modifierTypes.TM_GREAT,
-            modifierTypes.MEMORY_MUSHROOM,
-          ],
-          fillRemaining: true,
-        });
+        setEncounterRewards(scene, { guaranteedModifierTypeFuncs: [modifierTypes.TM_COMMON, modifierTypes.TM_GREAT, modifierTypes.MEMORY_MUSHROOM], fillRemaining: true });
 
         // Seed offsets to remove possibility of different trainers having exact same teams
         let ret;
@@ -184,14 +164,7 @@ export const MysteriousChallengersEncounter: IMysteryEncounter =
         // Spawn hard fight with ULTRA/GREAT reward (can improve with luck)
         const config: EnemyPartyConfig = encounter.enemyPartyConfigs[1];
 
-        setEncounterRewards(scene, {
-          guaranteedModifierTiers: [
-            ModifierTier.ULTRA,
-            ModifierTier.GREAT,
-            ModifierTier.GREAT,
-          ],
-          fillRemaining: true,
-        });
+        setEncounterRewards(scene, { guaranteedModifierTiers: [ModifierTier.ULTRA, ModifierTier.GREAT, ModifierTier.GREAT], fillRemaining: true });
 
         // Seed offsets to remove possibility of different trainers having exact same teams
         let ret;
@@ -219,14 +192,7 @@ export const MysteriousChallengersEncounter: IMysteryEncounter =
         // To avoid player level snowballing from picking this option
         encounter.expMultiplier = 0.9;
 
-        setEncounterRewards(scene, {
-          guaranteedModifierTiers: [
-            ModifierTier.ROGUE,
-            ModifierTier.ULTRA,
-            ModifierTier.GREAT,
-          ],
-          fillRemaining: true,
-        });
+        setEncounterRewards(scene, { guaranteedModifierTiers: [ModifierTier.ROGUE, ModifierTier.ULTRA, ModifierTier.GREAT], fillRemaining: true });
 
         // Seed offsets to remove possibility of different trainers having exact same teams
         let ret;

--- a/src/data/mystery-encounters/encounters/mysterious-chest-encounter.ts
+++ b/src/data/mystery-encounters/encounters/mysterious-chest-encounter.ts
@@ -15,7 +15,7 @@ import IMysteryEncounter, {
   MysteryEncounterBuilder,
   MysteryEncounterTier,
 } from "../mystery-encounter";
-import { MysteryEncounterOptionBuilder } from "../mystery-encounter-option";
+import { EncounterOptionMode, MysteryEncounterOptionBuilder } from "../mystery-encounter-option";
 
 export const MysteriousChestEncounter: IMysteryEncounter =
   MysteryEncounterBuilder.withEncounterType(
@@ -44,6 +44,7 @@ export const MysteriousChestEncounter: IMysteryEncounter =
     .withQuery("mysteryEncounter:mysterious_chest_query")
     .withOption(
       new MysteryEncounterOptionBuilder()
+        .withOptionMode(EncounterOptionMode.DEFAULT)
         .withDialogue({
           buttonLabel: "mysteryEncounter:mysterious_chest_option_1_label",
           buttonTooltip: "mysteryEncounter:mysterious_chest_option_1_tooltip",

--- a/src/data/mystery-encounters/encounters/shady-vitamin-dealer-encounter.ts
+++ b/src/data/mystery-encounters/encounters/shady-vitamin-dealer-encounter.ts
@@ -1,11 +1,4 @@
-import {
-  generateModifierTypeOption,
-  leaveEncounterWithoutBattle,
-  queueEncounterMessage,
-  selectPokemonForOption,
-  setEncounterExp,
-  updatePlayerMoney,
-} from "#app/data/mystery-encounters/mystery-encounter-utils";
+import { generateModifierTypeOption, leaveEncounterWithoutBattle, queueEncounterMessage, selectPokemonForOption, setEncounterExp, updatePlayerMoney, } from "#app/data/mystery-encounters/mystery-encounter-utils";
 import { StatusEffect } from "#app/data/status-effect";
 import Pokemon, { PlayerPokemon } from "#app/field/pokemon";
 import { modifierTypes } from "#app/modifier/modifier-type";
@@ -14,11 +7,8 @@ import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { Species } from "#enums/species";
 import i18next from "i18next";
 import BattleScene from "../../../battle-scene";
-import IMysteryEncounter, {
-  MysteryEncounterBuilder,
-  MysteryEncounterTier,
-} from "../mystery-encounter";
-import { MysteryEncounterOptionBuilder } from "../mystery-encounter-option";
+import IMysteryEncounter, { MysteryEncounterBuilder, MysteryEncounterTier, } from "../mystery-encounter";
+import { EncounterOptionMode, MysteryEncounterOptionBuilder } from "../mystery-encounter-option";
 import { MoneyRequirement } from "../mystery-encounter-requirements";
 
 /** the i18n namespace for this encounter */
@@ -63,6 +53,7 @@ export const ShadyVitaminDealerEncounter: IMysteryEncounter =
     .withQuery(`${namespace}_query`)
     .withOption(
       new MysteryEncounterOptionBuilder()
+        .withOptionMode(EncounterOptionMode.DISABLED_OR_DEFAULT)
         .withSceneMoneyRequirement(0, 2) // Wave scaling money multiplier of 2
         .withDialogue({
           buttonLabel: `${namespace}_option_1_label`,
@@ -77,17 +68,11 @@ export const ShadyVitaminDealerEncounter: IMysteryEncounter =
           const encounter = scene.currentBattle.mysteryEncounter;
           const onPokemonSelected = (pokemon: PlayerPokemon) => {
             // Update money
-            updatePlayerMoney(
-              scene,
-              -(encounter.options[0].requirements[0] as MoneyRequirement)
-                .requiredMoney
-            );
+            updatePlayerMoney(scene, -(encounter.options[0].requirements[0] as MoneyRequirement).requiredMoney);
             // Calculate modifiers and dialogue tokens
             const modifiers = [
-              generateModifierTypeOption(scene, modifierTypes.BASE_STAT_BOOSTER)
-                .type,
-              generateModifierTypeOption(scene, modifierTypes.BASE_STAT_BOOSTER)
-                .type,
+              generateModifierTypeOption(scene, modifierTypes.BASE_STAT_BOOSTER).type,
+              generateModifierTypeOption(scene, modifierTypes.BASE_STAT_BOOSTER).type,
             ];
             encounter.setDialogueToken("boost1", modifiers[0].name);
             encounter.setDialogueToken("boost2", modifiers[1].name);
@@ -100,10 +85,7 @@ export const ShadyVitaminDealerEncounter: IMysteryEncounter =
           // Only Pokemon that can gain benefits are above 1/3rd HP with no status
           const selectableFilter = (pokemon: Pokemon) => {
             // If pokemon meets primary pokemon reqs, it can be selected
-            const meetsReqs = encounter.pokemonMeetsPrimaryRequirements(
-              scene,
-              pokemon
-            );
+            const meetsReqs = encounter.pokemonMeetsPrimaryRequirements(scene, pokemon);
             if (!meetsReqs) {
               return i18next.t(`${namespace}_invalid_selection`);
             }
@@ -111,12 +93,7 @@ export const ShadyVitaminDealerEncounter: IMysteryEncounter =
             return null;
           };
 
-          return selectPokemonForOption(
-            scene,
-            onPokemonSelected,
-            null,
-            selectableFilter
-          );
+          return selectPokemonForOption(scene, onPokemonSelected, null, selectableFilter);
         })
         .withOptionPhase(async (scene: BattleScene) => {
           // Choose Cheap Option
@@ -162,6 +139,8 @@ export const ShadyVitaminDealerEncounter: IMysteryEncounter =
     )
     .withOption(
       new MysteryEncounterOptionBuilder()
+        .withOptionMode(EncounterOptionMode.DISABLED_OR_DEFAULT)
+        .withSceneMoneyRequirement(0, 5) // Wave scaling money multiplier of 5
         .withDialogue({
           buttonLabel: `${namespace}_option_2_label`,
           buttonTooltip: `${namespace}_option_2_tooltip`,
@@ -171,22 +150,15 @@ export const ShadyVitaminDealerEncounter: IMysteryEncounter =
             },
           ],
         })
-        .withSceneMoneyRequirement(0, 5) // Wave scaling money multiplier of 5
         .withPreOptionPhase(async (scene: BattleScene): Promise<boolean> => {
           const encounter = scene.currentBattle.mysteryEncounter;
           const onPokemonSelected = (pokemon: PlayerPokemon) => {
             // Update money
-            updatePlayerMoney(
-              scene,
-              -(encounter.options[1].requirements[0] as MoneyRequirement)
-                .requiredMoney
-            );
+            updatePlayerMoney(scene, -(encounter.options[1].requirements[0] as MoneyRequirement).requiredMoney);
             // Calculate modifiers and dialogue tokens
             const modifiers = [
-              generateModifierTypeOption(scene, modifierTypes.BASE_STAT_BOOSTER)
-                .type,
-              generateModifierTypeOption(scene, modifierTypes.BASE_STAT_BOOSTER)
-                .type,
+              generateModifierTypeOption(scene, modifierTypes.BASE_STAT_BOOSTER).type,
+              generateModifierTypeOption(scene, modifierTypes.BASE_STAT_BOOSTER).type,
             ];
             encounter.setDialogueToken("boost1", modifiers[0].name);
             encounter.setDialogueToken("boost2", modifiers[1].name);
@@ -199,10 +171,7 @@ export const ShadyVitaminDealerEncounter: IMysteryEncounter =
           // Only Pokemon that can gain benefits are above 1/3rd HP with no status
           const selectableFilter = (pokemon: Pokemon) => {
             // If pokemon meets primary pokemon reqs, it can be selected
-            const meetsReqs = encounter.pokemonMeetsPrimaryRequirements(
-              scene,
-              pokemon
-            );
+            const meetsReqs = encounter.pokemonMeetsPrimaryRequirements(scene, pokemon);
             if (!meetsReqs) {
               return i18next.t(`${namespace}_invalid_selection`);
             }
@@ -210,12 +179,7 @@ export const ShadyVitaminDealerEncounter: IMysteryEncounter =
             return null;
           };
 
-          return selectPokemonForOption(
-            scene,
-            onPokemonSelected,
-            null,
-            selectableFilter
-          );
+          return selectPokemonForOption(scene, onPokemonSelected, null, selectableFilter);
         })
         .withOptionPhase(async (scene: BattleScene) => {
           // Choose Expensive Option

--- a/src/data/mystery-encounters/encounters/sleeping-snorlax-encounter.ts
+++ b/src/data/mystery-encounters/encounters/sleeping-snorlax-encounter.ts
@@ -7,22 +7,10 @@ import BattleScene from "../../../battle-scene";
 import * as Utils from "../../../utils";
 import { getPokemonSpecies } from "../../pokemon-species";
 import { Status, StatusEffect } from "../../status-effect";
-import IMysteryEncounter, {
-  MysteryEncounterBuilder,
-  MysteryEncounterTier,
-} from "../mystery-encounter";
-import { MysteryEncounterOptionBuilder } from "../mystery-encounter-option";
+import IMysteryEncounter, { MysteryEncounterBuilder, MysteryEncounterTier, } from "../mystery-encounter";
+import { EncounterOptionMode, MysteryEncounterOptionBuilder } from "../mystery-encounter-option";
 import { MoveRequirement } from "../mystery-encounter-requirements";
-import {
-  EnemyPartyConfig,
-  EnemyPokemonConfig,
-  generateModifierTypeOption,
-  initBattleWithEnemyConfig,
-  leaveEncounterWithoutBattle,
-  queueEncounterMessage,
-  setEncounterExp,
-  setEncounterRewards,
-} from "../mystery-encounter-utils";
+import { EnemyPartyConfig, EnemyPokemonConfig, generateModifierTypeOption, initBattleWithEnemyConfig, leaveEncounterWithoutBattle, queueEncounterMessage, setEncounterExp, setEncounterRewards, } from "../mystery-encounter-utils";
 
 /** i18n namespace for the encounter */
 const namespace = "mysteryEncounter:sleeping_snorlax";
@@ -152,6 +140,7 @@ export const SleepingSnorlaxEncounter: IMysteryEncounter =
     )
     .withOption(
       new MysteryEncounterOptionBuilder()
+        .withOptionMode(EncounterOptionMode.DISABLED_OR_SPECIAL)
         .withPrimaryPokemonRequirement(new MoveRequirement(STEALING_MOVES))
         .withDialogue({
           buttonLabel: `${namespace}_option_3_label`,

--- a/src/data/mystery-encounters/encounters/training-session-encounter.ts
+++ b/src/data/mystery-encounters/encounters/training-session-encounter.ts
@@ -1,12 +1,6 @@
 import { Ability, allAbilities } from "#app/data/ability";
-import {
-  EnemyPartyConfig,
-  getEncounterText,
-  initBattleWithEnemyConfig,
-  selectPokemonForOption,
-  setEncounterRewards,
-} from "#app/data/mystery-encounters/mystery-encounter-utils";
-import { Nature, getNatureName } from "#app/data/nature";
+import { EnemyPartyConfig, getEncounterText, initBattleWithEnemyConfig, selectPokemonForOption, setEncounterRewards, } from "#app/data/mystery-encounters/mystery-encounter-utils";
+import { getNatureName, Nature } from "#app/data/nature";
 import { speciesStarters } from "#app/data/pokemon-species";
 import { Stat } from "#app/data/pokemon-stat";
 import { PlayerPokemon } from "#app/field/pokemon";
@@ -20,11 +14,8 @@ import { randSeedShuffle } from "#app/utils";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import BattleScene from "../../../battle-scene";
-import IMysteryEncounter, {
-  MysteryEncounterBuilder,
-  MysteryEncounterTier,
-} from "../mystery-encounter";
-import { MysteryEncounterOptionBuilder } from "../mystery-encounter-option";
+import IMysteryEncounter, { MysteryEncounterBuilder, MysteryEncounterTier, } from "../mystery-encounter";
+import { EncounterOptionMode, MysteryEncounterOptionBuilder } from "../mystery-encounter-option";
 
 /** The i18n namespace for the encounter */
 const namespace = "mysteryEncounter:training_session";
@@ -54,6 +45,7 @@ export const TrainingSessionEncounter: IMysteryEncounter =
     .withQuery(`${namespace}_query`)
     .withOption(
       new MysteryEncounterOptionBuilder()
+        .withOptionMode(EncounterOptionMode.DEFAULT)
         .withDialogue({
           buttonLabel: `${namespace}_option_1_label`,
           buttonTooltip: `${namespace}_option_1_tooltip`,
@@ -190,6 +182,7 @@ export const TrainingSessionEncounter: IMysteryEncounter =
     )
     .withOption(
       new MysteryEncounterOptionBuilder()
+        .withOptionMode(EncounterOptionMode.DEFAULT)
         .withDialogue({
           buttonLabel: `${namespace}_option_2_label`,
           buttonTooltip: `${namespace}_option_2_tooltip`,
@@ -275,6 +268,7 @@ export const TrainingSessionEncounter: IMysteryEncounter =
     )
     .withOption(
       new MysteryEncounterOptionBuilder()
+        .withOptionMode(EncounterOptionMode.DEFAULT)
         .withDialogue({
           buttonLabel: `${namespace}_option_3_label`,
           buttonTooltip: `${namespace}_option_3_tooltip`,

--- a/src/data/mystery-encounters/mystery-encounter-option.ts
+++ b/src/data/mystery-encounters/mystery-encounter-option.ts
@@ -150,7 +150,7 @@ export class MysteryEncounterOptionBuilder implements Partial<MysteryEncounterOp
   dialogue?: OptionTextDisplay;
 
   withOptionMode(optionMode: EncounterOptionMode): this & Pick<MysteryEncounterOption, "optionMode"> {
-    return Object.assign(this, { optionMode: optionMode });
+    return Object.assign(this, { optionMode });
   }
 
   withSceneRequirement(requirement: EncounterSceneRequirement): this & Required<Pick<MysteryEncounterOption, "requirements">> {

--- a/src/data/mystery-encounters/mystery-encounter-option.ts
+++ b/src/data/mystery-encounters/mystery-encounter-option.ts
@@ -3,24 +3,29 @@ import { PlayerPokemon } from "#app/field/pokemon";
 import BattleScene from "../../battle-scene";
 import * as Utils from "../../utils";
 import { EncounterPokemonRequirement, EncounterSceneRequirement, MoneyRequirement } from "./mystery-encounter-requirements";
-import { isNullOrUndefined } from "../../utils";
+
+export enum EncounterOptionMode {
+  /** Default style */
+  DEFAULT,
+  /** Disabled on requirements not met, default style on requirements met */
+  DISABLED_OR_DEFAULT,
+  /** Default style on requirements not met, special style on requirements met */
+  DEFAULT_OR_SPECIAL,
+  /** Disabled on requirements not met, special style on requirements met */
+  DISABLED_OR_SPECIAL
+}
 
 
 export type OptionPhaseCallback = (scene: BattleScene) => Promise<void | boolean>;
 
 export default interface MysteryEncounterOption {
+  optionMode: EncounterOptionMode;
   requirements?: EncounterSceneRequirement[];
   primaryPokemonRequirements?: EncounterPokemonRequirement[];
   secondaryPokemonRequirements?: EncounterPokemonRequirement[];
   primaryPokemon?: PlayerPokemon;
   secondaryPokemon?: PlayerPokemon[];
   excludePrimaryFromSecondaryRequirements?: boolean;
-  /**
-   * There are two modes of option requirements:
-   * 1 (DEFAULT): Option is completely disabled if requirements are not met (unselectable and greyed out)
-   * 2: Option is *NOT* disabled if requirements are not met
-   */
-  isDisabledOnRequirementsNotMet?: boolean;
 
   /**
    * Dialogue object containing all the dialogue, messages, tooltips, etc. for this option
@@ -42,7 +47,6 @@ export default class MysteryEncounterOption implements MysteryEncounterOption {
     this.requirements = this.requirements ? this.requirements : [];
     this.primaryPokemonRequirements = this.primaryPokemonRequirements ? this.primaryPokemonRequirements : [];
     this.secondaryPokemonRequirements = this.secondaryPokemonRequirements ? this.secondaryPokemonRequirements : [];
-    this.isDisabledOnRequirementsNotMet = isNullOrUndefined(this.isDisabledOnRequirementsNotMet) ? true : this.isDisabledOnRequirementsNotMet;
   }
 
   hasRequirements?() {
@@ -134,6 +138,7 @@ export default class MysteryEncounterOption implements MysteryEncounterOption {
 
 
 export class MysteryEncounterOptionBuilder implements Partial<MysteryEncounterOption> {
+  optionMode?: EncounterOptionMode;
   requirements?: EncounterSceneRequirement[] = [];
   primaryPokemonRequirements?: EncounterPokemonRequirement[] = [];
   secondaryPokemonRequirements ?: EncounterPokemonRequirement[] = [];
@@ -143,6 +148,10 @@ export class MysteryEncounterOptionBuilder implements Partial<MysteryEncounterOp
   onOptionPhase?: OptionPhaseCallback;
   onPostOptionPhase?: OptionPhaseCallback;
   dialogue?: OptionTextDisplay;
+
+  withOptionMode(optionMode: EncounterOptionMode): this & Pick<MysteryEncounterOption, "optionMode"> {
+    return Object.assign(this, { optionMode: optionMode });
+  }
 
   withSceneRequirement(requirement: EncounterSceneRequirement): this & Required<Pick<MysteryEncounterOption, "requirements">> {
     this.requirements.push(requirement);
@@ -178,11 +187,6 @@ export class MysteryEncounterOptionBuilder implements Partial<MysteryEncounterOp
     this.secondaryPokemonRequirements.push(requirement);
     this.excludePrimaryFromSecondaryRequirements = excludePrimaryFromSecondaryRequirements;
     return Object.assign(this, { secondaryPokemonRequirements: this.secondaryPokemonRequirements });
-  }
-
-  withDisabledOnRequirementsNotMet(disabled: boolean): this & Required<Pick<MysteryEncounterOption, "isDisabledOnRequirementsNotMet">> {
-    this.isDisabledOnRequirementsNotMet = disabled;
-    return Object.assign(this, { isDisabledOnRequirementsNotMet: this.isDisabledOnRequirementsNotMet });
   }
 
   withDialogue(dialogue: OptionTextDisplay) {

--- a/src/data/mystery-encounters/mystery-encounter.ts
+++ b/src/data/mystery-encounters/mystery-encounter.ts
@@ -9,7 +9,7 @@ import { StatusEffect } from "../status-effect";
 import MysteryEncounterDialogue, {
   OptionTextDisplay
 } from "./mystery-encounter-dialogue";
-import MysteryEncounterOption, { MysteryEncounterOptionBuilder, OptionPhaseCallback } from "./mystery-encounter-option";
+import MysteryEncounterOption, { EncounterOptionMode, MysteryEncounterOptionBuilder, OptionPhaseCallback } from "./mystery-encounter-option";
 import {
   EncounterPokemonRequirement,
   EncounterSceneRequirement,
@@ -136,7 +136,7 @@ export default class IMysteryEncounter implements IMysteryEncounter {
       Object.assign(this, encounter);
     }
     this.encounterTier = this.encounterTier ? this.encounterTier : MysteryEncounterTier.COMMON;
-    this.dialogue = {};
+    this.dialogue = this.dialogue ?? {};
     this.encounterVariant = MysteryEncounterVariant.DEFAULT;
     this.requirements = this.requirements ? this.requirements : [];
     this.hideBattleIntroMessage = !isNullOrUndefined(this.hideBattleIntroMessage) ? this.hideBattleIntroMessage : false;
@@ -397,7 +397,7 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
    * @returns
    */
   withSimpleOption(dialogue: OptionTextDisplay, callback: OptionPhaseCallback) {
-    return this.withOption(new MysteryEncounterOptionBuilder().withDialogue(dialogue).withOptionPhase(callback).build());
+    return this.withOption(new MysteryEncounterOptionBuilder().withOptionMode(EncounterOptionMode.DEFAULT).withDialogue(dialogue).withOptionPhase(callback).build());
   }
 
   /**


### PR DESCRIPTION
4 Modes that each Option must define (DEFAULT is default):
- DEFAULT (standard styling)
- DISABLED_OR_DEFAULT (Disabled on requirements not met, default style on requirements met)
- DEFAULT_OR_SPECIAL (Default style on requirements not met, special style on requirements met)
- DISABLED_OR_SPECIAL (Disabled on requirements not met, special style on requirements met)

##Examples

DISABLED_OR_DEFAULT
Disabled (1) vs Default (2)
![image](https://github.com/user-attachments/assets/cf27cee3-b19c-4a6e-9f1d-5e2e471523d1)

DEFAULT_OR_SPECIAL
Default (option still clickable without requirements met)
![image](https://github.com/user-attachments/assets/c6a97d81-2c3d-44ea-ab9d-cd1e949dc281)
Special (option is green with requirements met)
![image](https://github.com/user-attachments/assets/cbfa472c-0c6e-42a1-a1f0-97221ce7b65f)

DISABLED_OR_SPECIAL
Disabled (option not clickable without requirements met)
![image](https://github.com/user-attachments/assets/5f796ba7-eb3d-402c-be0b-a282b7f11e3c)
Special (option is green with requirements met)
![image](https://github.com/user-attachments/assets/27f7fb91-5b75-47cb-8513-3d944d74ad1b)
