### PR TITLE
add i18next money formatter for MEs

### DIFF
--- a/src/locales/en/mystery-encounter.ts
+++ b/src/locales/en/mystery-encounter.ts
@@ -86,9 +86,9 @@ export const mysteryEncounter: SimpleTranslationEntries = {
   "shady_vitamin_dealer_query": "Which deal will choose?",
   "shady_vitamin_dealer_invalid_selection": "Pokémon must be healthy enough.",
   "shady_vitamin_dealer_option_1_label": "The Cheap Deal",
-  "shady_vitamin_dealer_option_1_tooltip": "(-) Pay @[MONEY]{₽{{option1Money, number}}}\n(-) Side Effects?\n(+) Chosen Pokémon Gains 2 Random Vitamins",
+  "shady_vitamin_dealer_option_1_tooltip": "(-) Pay {{option1Money, money}}\n(-) Side Effects?\n(+) Chosen Pokémon Gains 2 Random Vitamins",
   "shady_vitamin_dealer_option_2_label": "The Pricey Deal",
-  "shady_vitamin_dealer_option_2_tooltip": "(-) Pay @[MONEY]{₽{{option2Money, number}}}\n(-) Side Effects?\n(+) Chosen Pokémon Gains 2 Random Vitamins",
+  "shady_vitamin_dealer_option_2_tooltip": "(-) Pay {{option2Money, money}}\n(-) Side Effects?\n(+) Chosen Pokémon Gains 2 Random Vitamins",
   "shady_vitamin_dealer_option_selected": `The man hands you two bottles and quickly disappears.
     \${{selectedPokemon}} gained {{boost1}} and {{boost2}} boosts!`,
   "shady_vitamin_dealer_damage_only": `But the medicine had some side effects!

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -136,6 +136,14 @@ export async function initI18n(): Promise<void> {
     postProcess: ["korean-postposition"],
   });
 
+  // Input: {{myMoneyValue, money}}
+  // Output: @[MONEY]{₽100,000,000} (useful for BBCode coloring of text)
+  // If you don't want the BBCode tag applied, just use 'number' formatter
+  i18next.services.formatter.add("money", (value, lng, options) => {
+    const numberFormattedString = Intl.NumberFormat(lng, options).format(value);
+    return `@[MONEY]{₽${numberFormattedString}}`;
+  });
+
   await initFonts();
 }
 


### PR DESCRIPTION
Still works the same as before, but requires less token garbage in the actual dialogue file


![image](https://github.com/user-attachments/assets/64f87e3d-039d-4933-8c34-4e8355a4b3ac)
